### PR TITLE
chore: add count cw721 activity

### DIFF
--- a/ci/config.json.ci
+++ b/ci/config.json.ci
@@ -17,7 +17,7 @@
     "startBlock": 0,
     "millisecondRepeatJobMedia": 10000,
     "mediaPerBatch": 10,
-    "millisecondRefreshMView": 3600000
+    "timeRefreshCw721Stats": "1 * * * *"
   },
   "crawlBlock": {
     "millisecondCrawl": 5000,

--- a/config.json
+++ b/config.json
@@ -17,7 +17,7 @@
     "startBlock": 0,
     "millisecondRepeatJobMedia": 10000,
     "mediaPerBatch": 10,
-    "millisecondRefreshMView": 3600000
+    "timeRefreshCw721Stats": "1 * * * *"
   },
   "crawlBlock": {
     "millisecondCrawl": 5000,

--- a/migrations/20230619071847_remove_view_count_cw721txs.ts
+++ b/migrations/20230619071847_remove_view_count_cw721txs.ts
@@ -1,0 +1,7 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.dropMaterializedViewIfExists('m_view_count_cw721_txs');
+}
+
+export async function down(knex: Knex): Promise<void> {}

--- a/migrations/20230619084858_create_table_cw721_stat.ts
+++ b/migrations/20230619084858_create_table_cw721_stat.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('cw721_contract_stat', (table) => {
+    table.increments();
+    table.integer('cw721_contract_id').unique().notNullable();
+    table.foreign('cw721_contract_id').references('cw721_contract.id');
+    table.integer('total_activity').defaultTo(0);
+    table.integer('transfer_24h').defaultTo(0);
+    table.dateTime('updated_at').defaultTo(knex.raw('now()'));
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('cw721_contract_stat');
+}

--- a/migrations/20230619084858_create_table_cw721_stat.ts
+++ b/migrations/20230619084858_create_table_cw721_stat.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.createTable('cw721_contract_stat', (table) => {
+  await knex.schema.createTable('cw721_contract_stats', (table) => {
     table.increments();
     table.integer('cw721_contract_id').unique().notNullable();
     table.foreign('cw721_contract_id').references('cw721_contract.id');
@@ -12,5 +12,5 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.dropTableIfExists('cw721_contract_stat');
+  await knex.schema.dropTableIfExists('cw721_contract_stats');
 }

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -33,7 +33,7 @@ export const BULL_JOB_NAME = {
   CRAWL_TRANSACTION: 'crawl:transaction',
   HANDLE_TRANSACTION: 'handle:transaction',
   HANDLE_CW721_TRANSACTION: 'handle:cw721-tx',
-  REFRESH_CW721_M_VIEW: 'refresh:cw721-m-view',
+  REFRESH_CW721_STATS: 'refresh:cw721-stats',
   CRAWL_PROPOSAL: 'crawl:proposal',
   CRAWL_TALLY_PROPOSAL: 'crawl:tally-proposal',
   COUNT_VOTE_PROPOSAL: 'handle:count-vote-proposal',

--- a/src/models/cw721_stat.ts
+++ b/src/models/cw721_stat.ts
@@ -1,0 +1,40 @@
+import { Model } from 'objection';
+import BaseModel from './base';
+import CW721Contract from './cw721_contract';
+
+export default class CW721ContractStat extends BaseModel {
+  updated_at?: Date;
+
+  static get tableName() {
+    return 'cw721_contract_stat';
+  }
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['cw721_contract_id'],
+      properties: {
+        cw721_contract_id: { type: 'number' },
+        total_activity: { type: 'number' },
+        transfer_24h: { type: 'number' },
+      },
+    };
+  }
+
+  static get relationMappings() {
+    return {
+      cw721_contract: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: CW721Contract,
+        join: {
+          from: 'cw721_contract_stat.cw721_contract_id',
+          to: 'cw721_contract.id',
+        },
+      },
+    };
+  }
+
+  $beforeInsert() {
+    this.updated_at = new Date();
+  }
+}

--- a/src/models/cw721_stats.ts
+++ b/src/models/cw721_stats.ts
@@ -2,11 +2,11 @@ import { Model } from 'objection';
 import BaseModel from './base';
 import CW721Contract from './cw721_contract';
 
-export default class CW721ContractStat extends BaseModel {
+export default class CW721ContractStats extends BaseModel {
   updated_at?: Date;
 
   static get tableName() {
-    return 'cw721_contract_stat';
+    return 'cw721_contract_stats';
   }
 
   static get jsonSchema() {
@@ -27,7 +27,7 @@ export default class CW721ContractStat extends BaseModel {
         relation: Model.BelongsToOneRelation,
         modelClass: CW721Contract,
         join: {
-          from: 'cw721_contract_stat.cw721_contract_id',
+          from: 'cw721_contract_stats.cw721_contract_id',
           to: 'cw721_contract.id',
         },
       },

--- a/src/services/cw721/cw721.service.ts
+++ b/src/services/cw721/cw721.service.ts
@@ -18,12 +18,13 @@ import BullableService, { QueueHandler } from '../../base/bullable.service';
 import { Config, getHttpBatchClient } from '../../common';
 import { BULL_JOB_NAME, SERVICE } from '../../common/constant';
 import knex from '../../common/utils/db_connection';
-import { BlockCheckpoint, EventAttribute } from '../../models';
+import { Block, BlockCheckpoint, EventAttribute } from '../../models';
 import CW721Contract from '../../models/cw721_contract';
 import CW721Token from '../../models/cw721_token';
 import CW721Activity from '../../models/cw721_tx';
 import { SmartContract } from '../../models/smart_contract';
 import { getAttributeFrom } from '../../common/utils/smart_contract';
+import CW721ContractStat from '../../models/cw721_stat';
 
 const { NODE_ENV } = Config;
 
@@ -222,16 +223,16 @@ export default class Cw721HandlerService extends BullableService {
         }
       );
       await this.createJob(
-        BULL_JOB_NAME.REFRESH_CW721_M_VIEW,
-        BULL_JOB_NAME.REFRESH_CW721_M_VIEW,
+        BULL_JOB_NAME.REFRESH_CW721_STATS,
+        BULL_JOB_NAME.REFRESH_CW721_STATS,
         {},
         {
-          removeOnComplete: true,
+          removeOnComplete: { count: 1 },
           removeOnFail: {
             count: 3,
           },
           repeat: {
-            every: config.cw721.millisecondRefreshMView,
+            pattern: config.cw721.timeRefreshCw721Stats,
           },
         }
       );
@@ -574,14 +575,59 @@ export default class Cw721HandlerService extends BullableService {
   }
 
   @QueueHandler({
-    queueName: BULL_JOB_NAME.REFRESH_CW721_M_VIEW,
-    jobName: BULL_JOB_NAME.REFRESH_CW721_M_VIEW,
+    queueName: BULL_JOB_NAME.REFRESH_CW721_STATS,
+    jobName: BULL_JOB_NAME.REFRESH_CW721_STATS,
   })
   async jobHandlerRefresh(): Promise<void> {
-    await this.refreshMaterialView();
+    await this.refreshCw721Stats();
   }
 
-  async refreshMaterialView() {
-    await knex.schema.refreshMaterializedView('m_view_count_cw721_txs');
+  async refreshCw721Stats(): Promise<void> {
+    const cw721Stats = await this.calCw721Stats();
+
+    // Mapping cw721 stats.
+    const listCw721Stats = cw721Stats.map((cw721Stat) =>
+      CW721ContractStat.fromJson({
+        cw721_contract_id: cw721Stat.cw721_contract_id,
+        total_activity: cw721Stat.total_activity,
+        transfer_24h: cw721Stat.transfer_24h,
+      })
+    );
+
+    // Upsert cw721 stats
+    await CW721ContractStat.query()
+      .insert(listCw721Stats)
+      .onConflict('cw721_contract_id')
+      .merge()
+      .returning('id');
+  }
+
+  async calCw721Stats(): Promise<CW721Contract[]> {
+    // Get once block height 24h ago.
+    const blockSince24hAgo = await Block.query()
+      .select('height')
+      .where('time', '<=', knex.raw("now() - '24 hours'::interval"))
+      .orderBy('height', 'desc')
+      .limit(1);
+
+    // Calculate total activity and transfer_24h of cw721
+    return CW721Contract.query()
+      .count('cw721_activity.id AS total_activity')
+      .select(
+        knex.raw(
+          "SUM( CASE WHEN cw721_activity.height > ? AND cw721_activity.action != '' THEN 1 ELSE 0 END ) AS transfer_24h",
+          blockSince24hAgo[0]?.height
+        )
+      )
+      .select('cw721_contract.id as cw721_contract_id')
+      .where('cw721_contract.track', '=', true)
+      .andWhere('smart_contract.name', '!=', 'crates.io:cw4973')
+      .join(
+        'cw721_activity',
+        'cw721_contract.id',
+        'cw721_activity.cw721_contract_id'
+      )
+      .join('smart_contract', 'cw721_contract.contract_id', 'smart_contract.id')
+      .groupBy('cw721_contract.id');
   }
 }


### PR DESCRIPTION
Add table cw721_contract_stat to count total activity and transfer 24h
Add job repeat at minute 1 of each hour to update data of all table cw721_contract_stat.
Raw sql:
`SELECT count("cw721_activity"."id") AS "total_activity",
       SUM(CASE
               WHEN cw721_activity.height > ?
                    AND cw721_activity.action != '' THEN 1
               ELSE 0
           END) AS transfer_24h,
       "cw721_contract"."id" AS "cw721_contract_id"
FROM "cw721_contract"
INNER JOIN "cw721_activity" ON "cw721_contract"."id" = "cw721_activity"."cw721_contract_id"
INNER JOIN "smart_contract" ON "cw721_contract"."contract_id" = "smart_contract"."id"
WHERE "cw721_contract"."track" = ?
  AND "smart_contract"."name" != ?
GROUP BY "cw721_contract"."id"`