### PR TITLE
fix: fix count transfer24h cw721

### DIFF
--- a/src/services/cw721/cw721.service.ts
+++ b/src/services/cw721/cw721.service.ts
@@ -606,13 +606,14 @@ export default class Cw721HandlerService extends BullableService {
       .count('cw721_activity.id AS total_activity')
       .select(
         knex.raw(
-          "SUM( CASE WHEN cw721_activity.height >= ? AND cw721_activity.action != '' THEN 1 ELSE 0 END ) AS transfer_24h",
+          "SUM( CASE WHEN cw721_activity.height >= ? AND cw721_activity.action != 'instantiate' THEN 1 ELSE 0 END ) AS transfer_24h",
           blockSince24hAgo[0]?.height
         )
       )
       .select('cw721_contract.id as cw721_contract_id')
       .where('cw721_contract.track', '=', true)
       .andWhere('smart_contract.name', '!=', 'crates.io:cw4973')
+      .andWhere('cw721_activity.action', '!=', '')
       .join(
         'cw721_activity',
         'cw721_contract.id',


### PR DESCRIPTION
Not count instantiate in transfer 24h of cw721

sql
`SELECT
  count("cw721_activity"."id") AS "total_activity", 
  SUM(
    CASE WHEN cw721_activity.height >= 14279593
    AND cw721_activity.action != 'instantiate' THEN 1 ELSE 0 END
  ) AS transfer_24h, 
  "cw721_contract"."id" AS "cw721_contract_id" 
FROM 
  "cw721_contract" 
  INNER JOIN "cw721_activity" ON "cw721_contract"."id" = "cw721_activity"."cw721_contract_id" 
  INNER JOIN "smart_contract" ON "cw721_contract"."contract_id" = "smart_contract"."id" 
WHERE 
  "cw721_contract"."track" = true
  AND "smart_contract"."name" != 'crates.io:cw4973'
  AND cw721_activity.action != ''
GROUP BY 
  "cw721_contract"."id"
ORDER BY transfer_24h DESC
`