### PR TITLE
Feat/update coin transfer hasura and fix bug bulk insert coin transfer

### DIFF
--- a/ci/config.json.ci
+++ b/ci/config.json.ci
@@ -31,7 +31,8 @@
   "handleCoinTransfer": {
     "key": "handleCoinTransfer",
     "blocksPerCall": 100,
-    "millisecondCrawl": 3000
+    "millisecondCrawl": 3000,
+    "chunkSize": 1000
   },
   "handleTransaction": {
     "key": "handleTransaction",

--- a/config.json
+++ b/config.json
@@ -31,7 +31,8 @@
   "handleCoinTransfer": {
     "key": "handleCoinTransfer",
     "blocksPerCall": 100,
-    "millisecondCrawl": 3000
+    "millisecondCrawl": 3000,
+    "chunkSize": 1000
   },
   "handleTransaction": {
     "key": "handleTransaction",

--- a/hasura/metadata/databases/auratestnet/tables/public_coin_transfer.yaml
+++ b/hasura/metadata/databases/auratestnet/tables/public_coin_transfer.yaml
@@ -1,0 +1,19 @@
+table:
+  name: coin_transfer
+  schema: public
+select_permissions:
+  - role: internal_service
+    permission:
+      columns:
+        - id
+        - block_height
+        - tx_id
+        - tx_msg_id
+        - from
+        - to
+        - amount
+        - denom
+        - timestamp
+        - created_at
+      filter: {}
+      limit: 100

--- a/hasura/metadata/databases/euphoria/tables/public_coin_transfer.yaml
+++ b/hasura/metadata/databases/euphoria/tables/public_coin_transfer.yaml
@@ -1,0 +1,19 @@
+table:
+  name: coin_transfer
+  schema: public
+select_permissions:
+  - role: internal_service
+    permission:
+      columns:
+        - id
+        - block_height
+        - tx_id
+        - tx_msg_id
+        - from
+        - to
+        - amount
+        - denom
+        - timestamp
+        - created_at
+      filter: {}
+      limit: 100

--- a/hasura/metadata/databases/serenity/tables/public_coin_transfer.yaml
+++ b/hasura/metadata/databases/serenity/tables/public_coin_transfer.yaml
@@ -1,0 +1,19 @@
+table:
+  name: coin_transfer
+  schema: public
+select_permissions:
+  - role: internal_service
+    permission:
+      columns:
+        - id
+        - block_height
+        - tx_id
+        - tx_msg_id
+        - from
+        - to
+        - amount
+        - denom
+        - timestamp
+        - created_at
+      filter: {}
+      limit: 100

--- a/hasura/metadata/databases/xstaxy/tables/public_coin_transfer.yaml
+++ b/hasura/metadata/databases/xstaxy/tables/public_coin_transfer.yaml
@@ -1,0 +1,19 @@
+table:
+  name: coin_transfer
+  schema: public
+select_permissions:
+  - role: internal_service
+    permission:
+      columns:
+        - id
+        - block_height
+        - tx_id
+        - tx_msg_id
+        - from
+        - to
+        - amount
+        - denom
+        - timestamp
+        - created_at
+      filter: {}
+      limit: 100

--- a/src/services/crawl-tx/coin_transfer.service.ts
+++ b/src/services/crawl-tx/coin_transfer.service.ts
@@ -195,7 +195,11 @@ export default class CoinTransferService extends BullableService {
 
       if (coinTransfers.length > 0) {
         this.logger.info(`INSERTING ${coinTransfers.length} COIN TRANSFER`);
-        await CoinTransfer.query().transacting(trx).insert(coinTransfers);
+        await trx.batchInsert(
+          CoinTransfer.tableName,
+          coinTransfers,
+          config.handleCoinTransfer.chunkSize
+        );
       }
     });
   }


### PR DESCRIPTION
- Update table coin transfer on hasura documentation
- Currently insert more than 40k rows into coin transfer per one time run so use batch insert 1000 rows each time