### PR TITLE
fix: remove numberOfBlockPerCall to use blocksPerCall in crawl block, tx

### DIFF
--- a/ci/config.json.ci
+++ b/ci/config.json.ci
@@ -26,13 +26,14 @@
   },
   "crawlBlock": {
     "millisecondCrawl": 5000,
-    "numberOfBlockPerCall": 100,
+    "blocksPerCall": 100,
     "startBlock": 4860000,
     "saveRawLog": true
   },
   "crawlTransaction": {
+    "key": "crawlTransaction",
     "millisecondCrawl": 5000,
-    "numberOfBlockPerCall": 100,
+    "blocksPerCall": 100,
     "chunkSize": 1000
   },
   "handleCoinTransfer": {

--- a/config.json
+++ b/config.json
@@ -26,13 +26,14 @@
   },
   "crawlBlock": {
     "millisecondCrawl": 5000,
-    "numberOfBlockPerCall": 100,
+    "blocksPerCall": 100,
     "startBlock": 4860000,
     "saveRawLog": true
   },
   "crawlTransaction": {
+    "key": "crawlTransaction",
     "millisecondCrawl": 1000,
-    "numberOfBlockPerCall": 100,
+    "blocksPerCall": 100,
     "chunkSize": 1000
   },
   "handleCoinTransfer": {

--- a/src/services/crawl-block/crawl_block.service.ts
+++ b/src/services/crawl-block/crawl_block.service.ts
@@ -94,7 +94,7 @@ export default class CrawlBlockService extends BullableService {
     // crawl block from startBlock to endBlock
     const startBlock = this._currentBlock + 1;
 
-    let endBlock = startBlock + config.crawlBlock.numberOfBlockPerCall - 1;
+    let endBlock = startBlock + config.crawlBlock.blocksPerCall - 1;
     if (endBlock > latestBlockNetwork) {
       endBlock = latestBlockNetwork;
     }

--- a/src/services/crawl-tx/crawl_tx.service.ts
+++ b/src/services/crawl-tx/crawl_tx.service.ts
@@ -54,7 +54,7 @@ export default class CrawlTxService extends BullableService {
       await BlockCheckpoint.getCheckpoint(
         BULL_JOB_NAME.CRAWL_TRANSACTION,
         [BULL_JOB_NAME.CRAWL_BLOCK],
-        config.handleTransaction.key
+        config.crawlTransaction.key
       );
 
     this.logger.info(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved configuration naming for clarity in block and transaction crawling services.
	- Enhanced efficiency in transaction processing with updated configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->