### PR TITLE
feat: create index to optimize query tx in account detail aurascan

### DIFF
--- a/migrations/20240320074436_create_index_owner_not_burned_cw721_token.ts
+++ b/migrations/20240320074436_create_index_owner_not_burned_cw721_token.ts
@@ -1,0 +1,11 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(
+    `CREATE INDEX IF NOT EXISTS cw721_token_owner_not_burned ON cw721_token USING btree (owner ASC NULLS LAST, burned ASC NULLS LAST) WHERE NOT burned;`
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`DROP INDEX IF EXISTS cw721_token_owner_not_burned`);
+}

--- a/migrations/20240320074436_create_index_owner_not_burned_cw721_token.ts
+++ b/migrations/20240320074436_create_index_owner_not_burned_cw721_token.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(
-    `CREATE INDEX IF NOT EXISTS cw721_token_owner_not_burned ON cw721_token USING btree (owner ASC NULLS LAST, burned ASC NULLS LAST) WHERE NOT burned;`
+    `CREATE INDEX IF NOT EXISTS cw721_token_owner_not_burned ON cw721_token USING btree (owner ASC NULLS LAST) WHERE NOT burned;`
   );
 }
 

--- a/migrations/20240320084001_create_tx_id_in_cw20_activity.ts
+++ b/migrations/20240320084001_create_tx_id_in_cw20_activity.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+import { Cw20Activity } from '../src/models';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('cw20_activity', (table) => {
+    table.integer('tx_id').index();
+  });
+
+  let currentId = 0;
+  const chunkSizeQuery = 10000;
+  let cw20Activities;
+  do {
+    cw20Activities = await knex.raw(
+      `SELECT cw20_activity.id as id, transaction.id as tx_id FROM cw20_activity JOIN transaction on cw20_activity.tx_hash = transaction.hash WHERE cw20_activity.id > ${currentId} ORDER BY id LIMIT ${chunkSizeQuery}`
+    );
+    if (cw20Activities.rows.length === 0) {
+      break;
+    }
+    const stringListUpdates = cw20Activities.rows
+      .map((update: any) => `(${update.id}, ${update.tx_id})`)
+      .join(',');
+    await knex.raw(
+      `UPDATE cw20_activity SET tx_id = temp.tx_id from (VALUES ${stringListUpdates}) as temp(id, tx_id) where temp.id = cw20_activity.id`
+    );
+    currentId = cw20Activities.rows[cw20Activities.rows.length - 1].id;
+  } while (cw20Activities.rows.length > 0);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('cw20_activity', (table) => {
+    table.dropColumn('tx_id');
+  });
+}

--- a/migrations/20240321015030_create_composite_index_tx_id_sender_in_tx_msg.ts
+++ b/migrations/20240321015030_create_composite_index_tx_id_sender_in_tx_msg.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('transaction_message', (table) => {
+    table.index(['sender', 'tx_id']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('transaction_message', (table) => {
+    table.dropIndex(['sender', 'tx_id']);
+  });
+}

--- a/src/models/cw20_activity.ts
+++ b/src/models/cw20_activity.ts
@@ -31,6 +31,8 @@ export class Cw20Activity extends BaseModel {
 
   tx_hash!: string;
 
+  tx_id!: number;
+
   static get tableName() {
     return 'cw20_activity';
   }

--- a/src/services/cw20/cw20.service.ts
+++ b/src/services/cw20/cw20.service.ts
@@ -207,6 +207,7 @@ export default class Cw20Service extends BullableService {
           ),
           height: event.height,
           tx_hash: event.hash,
+          tx_id: event.tx_id,
         })
       );
     if (newHistories.length > 0) {


### PR DESCRIPTION
- create index to optimize query in aurascan query nft, executed tx in account detail screen
- add tx_id to cw20_activity to use index id instead of tx_hash when join and sort cw20_activity and transaction