### PR TITLE
feat: add evm proxy history

### DIFF
--- a/config.json
+++ b/config.json
@@ -390,5 +390,10 @@
     "blocksPerCall": 100,
     "millisecondRepeatJob": 2000,
     "chunkSizeInsert": 1000
+  },
+  "crawlEvmProxyHistory": {
+    "key": "crawlEvmProxyHistory",
+    "blocksPerCall": 100,
+    "millisecondCrawl": 2000
   }
 }

--- a/migrations/20240326084123_add_unique_to_evm_proxy_history.ts
+++ b/migrations/20240326084123_add_unique_to_evm_proxy_history.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('evm_proxy_history', (table) => {
+    table.dropIndex('proxy_contract');
+    table.unique(['proxy_contract', 'block_height']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('evm_proxy_history', (table) => {
+    table.dropIndex(['proxy_contract', 'block_height']);
+    table.index('proxy_contract');
+  });
+}

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -137,6 +137,7 @@ export const BULL_JOB_NAME = {
   VERIFY_CONTRACT_EVM: 'verify:contract-evm',
   HANDLE_ERC20_CONTRACT: 'handle:erc20-contract',
   HANDLE_ERC20_ACTIVITY: 'handle:erc20-activity',
+  HANDLE_EVM_PROXY_HISTORY: 'handle:evm-proxy-history',
 };
 
 export const SERVICE = {
@@ -477,6 +478,10 @@ export const SERVICE = {
         key: 'createJobMapping',
         path: 'v1.SignatureMappingEVM.createJobMapping',
       },
+    },
+    CrawlEvmProxyHistory: {
+      key: 'CrawlEvmProxyHistory',
+      path: 'v1.CrawlEvmProxyHistory',
     },
   },
 };

--- a/src/models/evm_smart_contract.ts
+++ b/src/models/evm_smart_contract.ts
@@ -47,6 +47,9 @@ export class EVMSmartContract extends BaseModel {
       ERC20: 'ERC20',
       ERC721: 'ERC721',
       ERC1155: 'ERC1155',
+      PROXY_EIP_1967: 'PROXY_EIP_1967',
+      PROXY_EIP_1822: 'PROXY_EIP_1822',
+      PROXY_OPEN_ZEPPELIN_IMPLEMENTATION: 'PROXY_OPEN_ZEPPELIN_IMPLEMENTATION',
     };
   }
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -38,3 +38,4 @@ export * from './evm_contract_verification';
 export * from './evm_signature_mapping';
 export * from './erc20_contract';
 export * from './erc20_activity';
+export * from './evm_proxy_history';

--- a/src/services/evm/constant.ts
+++ b/src/services/evm/constant.ts
@@ -1,4 +1,5 @@
 import { id as keccak256Str } from 'ethers';
+import { EVMSmartContract } from '../../models';
 
 export const ABI_CHECK_INTERFACE_ERC_721 = [
   'balanceOf(address)',
@@ -49,12 +50,28 @@ export type DetectEVMProxyContract = {
   EIP?: string;
 };
 
-export enum EIPProxyContractSupportByteCode {
-  EIP_1967_LOGIC_SLOT = '360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc', // eip1967.proxy.implementation
-  EIP_1967_BEACON_SLOT = 'a3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50', // eip1967.proxy.beacon
-  EIP_1822_LOGIC_SLOT = 'c5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7', // PROXIABLE
-  OPEN_ZEPPELIN_IMPLEMENTATION_SLOT = '7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3', // org.zeppelinos.proxy.implementation
-}
+export const EIPProxyContractSupportByteCode = {
+  EIP_1967_IMPLEMENTATION: {
+    SLOT: '360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc', // eip1967.proxy.implementation
+    TYPE: EVMSmartContract.TYPES.PROXY_EIP_1967,
+  },
+  EIP_1967_BEACON: {
+    SLOT: 'a3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50', // eip1967.proxy.beacon
+    TYPE: EVMSmartContract.TYPES.PROXY_EIP_1967,
+  },
+  EIP_1967_ADMIN: {
+    SLOT: 'b53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103', // eip1967.proxy.admin
+    TYPE: EVMSmartContract.TYPES.PROXY_EIP_1967,
+  },
+  EIP_1822_IMPLEMENTATION: {
+    SLOT: 'c5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7', // PROXIABLE
+    TYPE: EVMSmartContract.TYPES.PROXY_EIP_1822,
+  },
+  OPEN_ZEPPELIN_IMPLEMENTATION: {
+    SLOT: '7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3', // org.zeppelinos.proxy.implementation
+    TYPE: EVMSmartContract.TYPES.PROXY_OPEN_ZEPPELIN_IMPLEMENTATION,
+  },
+};
 
 export const NULL_BYTE_CODE =
   '0x0000000000000000000000000000000000000000000000000000000000000000';

--- a/src/services/evm/crawl_contract_evm.service.ts
+++ b/src/services/evm/crawl_contract_evm.service.ts
@@ -12,15 +12,8 @@ import { BULL_JOB_NAME, SERVICE } from '../../common';
 import BullableService, { QueueHandler } from '../../base/bullable.service';
 import config from '../../../config.json' assert { type: 'json' };
 import knex from '../../common/utils/db_connection';
-import {
-  DetectEVMProxyContract,
-  EIPProxyContractSupportByteCode,
-  EVM_CONTRACT_METHOD_HEX_PREFIX,
-  EVM_DEFAULT_SLOT_BYTE_CODE_LENGTH,
-  EVM_PREFIX,
-  NULL_BYTE_CODE,
-  ZERO_ADDRESS,
-} from './constant';
+import { EVM_CONTRACT_METHOD_HEX_PREFIX } from './constant';
+import { ContractHelper } from './helpers/contract_helper';
 
 @Service({
   name: SERVICE.V1.CrawlSmartContractEVM.key,
@@ -28,6 +21,8 @@ import {
 })
 export default class CrawlSmartContractEVMService extends BullableService {
   etherJsClient!: ethers.AbstractProvider;
+
+  private contractHelper!: ContractHelper;
 
   public constructor(public broker: ServiceBroker) {
     super(broker);
@@ -128,7 +123,14 @@ export default class CrawlSmartContractEVMService extends BullableService {
               let creator;
               let createdHeight;
               let createdHash;
-              const type = this.detectContractTypeByCode(code);
+              let type = this.detectContractTypeByCode(code);
+              const implementContractInfo =
+                await this.contractHelper.isContractProxy(address);
+
+              if (implementContractInfo) {
+                type = implementContractInfo.EIP as any;
+              }
+
               const codeHash = keccak256(code);
               if (evmTx.data) {
                 const { data } = evmTx;
@@ -204,82 +206,9 @@ export default class CrawlSmartContractEVMService extends BullableService {
     return null;
   }
 
-  public async detectProxyContractByByteCode(
-    contractAddress: string,
-    byteCode: string,
-    byteCodeSlot: EIPProxyContractSupportByteCode
-  ): Promise<DetectEVMProxyContract> {
-    const resultReturn: DetectEVMProxyContract = {
-      logicContractAddress: '',
-      EIP: '',
-    };
-    const result = byteCode.includes(byteCodeSlot);
-
-    if (!result) throw Error('Not proxy contract!');
-
-    const storageSlotValue = await this.etherJsClient.getStorage(
-      contractAddress,
-      `${EVM_PREFIX}${byteCodeSlot}`,
-      'latest'
-    );
-
-    if (storageSlotValue === '0x' || storageSlotValue === NULL_BYTE_CODE)
-      throw Error('Invalid contract address!');
-
-    const logicAddress =
-      storageSlotValue.length === EVM_DEFAULT_SLOT_BYTE_CODE_LENGTH
-        ? `${EVM_PREFIX}${storageSlotValue.slice(-40)}`
-        : storageSlotValue;
-
-    if (logicAddress === ZERO_ADDRESS) throw Error('Zero contract detected!');
-
-    resultReturn.logicContractAddress = logicAddress;
-    resultReturn.EIP = _.findKey(
-      EIPProxyContractSupportByteCode,
-      (val) => val === byteCodeSlot
-    );
-    return resultReturn;
-  }
-
-  // Detect contract is proxy contract or not
-  public async isContractProxy(
-    contractAddress: string
-  ): Promise<DetectEVMProxyContract | null> {
-    const byteCode = await this.etherJsClient.getCode(contractAddress);
-    let result: DetectEVMProxyContract | null;
-
-    try {
-      result = await Promise.any([
-        this.detectProxyContractByByteCode(
-          contractAddress,
-          byteCode,
-          EIPProxyContractSupportByteCode.EIP_1967_LOGIC_SLOT
-        ),
-        this.detectProxyContractByByteCode(
-          contractAddress,
-          byteCode,
-          EIPProxyContractSupportByteCode.EIP_1967_BEACON_SLOT
-        ),
-        this.detectProxyContractByByteCode(
-          contractAddress,
-          byteCode,
-          EIPProxyContractSupportByteCode.EIP_1822_LOGIC_SLOT
-        ),
-        this.detectProxyContractByByteCode(
-          contractAddress,
-          byteCode,
-          EIPProxyContractSupportByteCode.OPEN_ZEPPELIN_IMPLEMENTATION_SLOT
-        ),
-      ]);
-    } catch (error) {
-      result = null;
-    }
-
-    return result;
-  }
-
   public async _start(): Promise<void> {
     this.etherJsClient = new EtherJsClient().etherJsClient;
+    this.contractHelper = new ContractHelper(this.etherJsClient);
     this.createJob(
       BULL_JOB_NAME.CRAWL_SMART_CONTRACT_EVM,
       BULL_JOB_NAME.CRAWL_SMART_CONTRACT_EVM,

--- a/src/services/evm/crawl_evm_proxy_history.service.ts
+++ b/src/services/evm/crawl_evm_proxy_history.service.ts
@@ -1,0 +1,206 @@
+/* eslint-disable @typescript-eslint/return-await */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable no-restricted-syntax */
+import { Service } from '@ourparentcenter/moleculer-decorators-extended';
+import { ServiceBroker } from 'moleculer';
+import { ethers } from 'ethers';
+import _ from 'lodash';
+import {
+  decodeAbiParameters,
+  parseAbiParameters,
+  keccak256,
+  toHex,
+} from 'viem';
+import { BULL_JOB_NAME, SERVICE } from '../../common';
+import BullableService, { QueueHandler } from '../../base/bullable.service';
+import config from '../../../config.json' assert { type: 'json' };
+import {
+  BlockCheckpoint,
+  EvmEvent,
+  EvmProxyHistory,
+  EVMSmartContract,
+} from '../../models';
+import { ContractHelper } from './helpers/contract_helper';
+import EtherJsClient from '../../common/utils/etherjs_client';
+import knex from '../../common/utils/db_connection';
+import { EIPProxyContractSupportByteCode } from './constant';
+
+const Erc1967Events = {
+  upgraded: {
+    event: keccak256(toHex('Upgraded(address)')), // Upgraded(address indexed implementation) Emitted when the implementation is upgraded.
+    abiParams: 'address implementation',
+  },
+  adminChanged: {
+    event: keccak256(toHex('AdminChanged(address,address)')), // AdminChanged(address previousAdmin, address newAdmin)  Emitted when the admin account has changed.
+    abiParams: 'address previousAdmin, address newAdmin',
+  },
+  beaconUpgraded: {
+    event: keccak256(toHex('BeaconUpgraded(address)')), // BeaconUpgraded(address indexed beacon) Emitted when the beacon is upgraded.
+    abiParams: 'address beacon',
+  },
+};
+
+@Service({
+  name: SERVICE.V1.CrawlEvmProxyHistory.key,
+  version: 1,
+})
+export default class CrawlProxyContractEVMService extends BullableService {
+  private etherJsClient!: ethers.AbstractProvider;
+
+  private contractHelper!: ContractHelper;
+
+  public constructor(public broker: ServiceBroker) {
+    super(broker);
+  }
+
+  @QueueHandler({
+    queueName: BULL_JOB_NAME.HANDLE_EVM_PROXY_HISTORY,
+    jobName: BULL_JOB_NAME.HANDLE_EVM_PROXY_HISTORY,
+  })
+  public async jobHandler() {
+    const newProxyHistories: EvmProxyHistory[] = [];
+    const [startBlock, endBlock, updateBlockCheckpoint] =
+      await BlockCheckpoint.getCheckpoint(
+        BULL_JOB_NAME.HANDLE_EVM_PROXY_HISTORY,
+        [BULL_JOB_NAME.CRAWL_SMART_CONTRACT_EVM],
+        config.crawlEvmProxyHistory.key
+      );
+    this.logger.info(
+      `Crawl Evm proxy history from block ${startBlock} to block ${endBlock}`
+    );
+    const evmEvents = await EvmEvent.query()
+      .select('*')
+      .where('block_height', '>', startBlock)
+      .andWhere('block_height', '<=', endBlock);
+    const proxyContractDb = await EVMSmartContract.query().whereIn('type', [
+      EVMSmartContract.TYPES.PROXY_EIP_1967,
+      EVMSmartContract.TYPES.PROXY_EIP_1822,
+      EVMSmartContract.TYPES.PROXY_OPEN_ZEPPELIN_IMPLEMENTATION,
+    ]);
+
+    for (const evmEvent of evmEvents) {
+      let [adminAddress, implementationAddress, beaconAddress]: unknown[] = [
+        null,
+        null,
+        null,
+      ];
+      const anyProxyHistory = await EvmProxyHistory.query()
+        .where('proxy_contract', '=', _.toLower(evmEvent.address))
+        .andWhereNot('last_updated_height', null);
+      const evmEventProxy: EVMSmartContract = _.find(proxyContractDb, {
+        address: evmEvent.address,
+      }) as EVMSmartContract;
+      const firstTimeCatchProxyEvent =
+        proxyContractDb.find((proxy) => proxy.address === evmEvent.address) &&
+        anyProxyHistory.length === 0;
+      const newJSONProxy = {} as any;
+
+      switch (evmEvent.topic0) {
+        case Erc1967Events.upgraded.event:
+          [implementationAddress] = decodeAbiParameters(
+            parseAbiParameters(Erc1967Events.upgraded.abiParams),
+            evmEvent.topic1 as any
+          );
+          break;
+        case Erc1967Events.adminChanged.event:
+          [, adminAddress] = decodeAbiParameters(
+            parseAbiParameters(Erc1967Events.adminChanged.abiParams),
+            toHex(evmEvent.data)
+          );
+          break;
+        case Erc1967Events.beaconUpgraded.event:
+          beaconAddress = decodeAbiParameters(
+            parseAbiParameters(Erc1967Events.beaconUpgraded.abiParams),
+            evmEvent.topic1 as any
+          );
+          break;
+        default:
+          if (firstTimeCatchProxyEvent) {
+            implementationAddress = await this.contractHelper.isContractProxy(
+              evmEvent.address,
+              _.find(
+                EIPProxyContractSupportByteCode,
+                (value, __) => value.TYPE === evmEventProxy.type
+              )?.SLOT
+            );
+
+            newJSONProxy.last_updated_height =
+              await this.etherJsClient.getBlockNumber();
+          }
+          break;
+      }
+
+      newJSONProxy.proxy_contract = _.toLower(evmEvent.address);
+      newJSONProxy.admin = _.toLower(adminAddress as string) || null;
+      newJSONProxy.implementation_contract =
+        _.toLower(implementationAddress as string) || beaconAddress || null;
+      newJSONProxy.block_height = evmEvent.block_height;
+      newJSONProxy.tx_hash = evmEvent.tx_hash;
+
+      newProxyHistories.push(EvmProxyHistory.fromJson(newJSONProxy));
+    }
+
+    const newProxyContractsToSave = _.filter(
+      newProxyHistories,
+      (proxyContract) =>
+        proxyContract.admin !== null ||
+        proxyContract.implementation_contract !== null
+    );
+
+    await knex.transaction(async (trx) => {
+      if (newProxyContractsToSave.length > 0) {
+        // Unique proxy contract when have multiple events in same block.
+        const groupedProxyContract = _.groupBy(
+          newProxyContractsToSave,
+          (proxy) => proxy.proxy_contract + proxy.block_height
+        );
+        const mergedProxyContract: EvmProxyHistory[] = _.map(
+          groupedProxyContract,
+          (group) =>
+            // eslint-disable-next-line consistent-return
+            _.mergeWith({}, ...group, (obj: any, attribute: null) => {
+              if (attribute === null) {
+                return obj;
+              }
+            })
+        );
+
+        await EvmProxyHistory.query()
+          .insert(mergedProxyContract)
+          .onConflict(['proxy_contract', 'block_height'])
+          .merge()
+          .returning('id')
+          .transacting(trx);
+      }
+
+      updateBlockCheckpoint.height = endBlock;
+      await BlockCheckpoint.query()
+        .insert(updateBlockCheckpoint)
+        .onConflict('job_name')
+        .merge()
+        .returning('id')
+        .transacting(trx);
+    });
+  }
+
+  public async _start() {
+    this.etherJsClient = new EtherJsClient().etherJsClient;
+    this.contractHelper = new ContractHelper(this.etherJsClient);
+
+    this.createJob(
+      BULL_JOB_NAME.HANDLE_EVM_PROXY_HISTORY,
+      BULL_JOB_NAME.HANDLE_EVM_PROXY_HISTORY,
+      {},
+      {
+        removeOnComplete: true,
+        removeOnFail: {
+          count: 3,
+        },
+        repeat: {
+          every: config.crawlEvmProxyHistory.millisecondCrawl,
+        },
+      }
+    );
+    return super._start();
+  }
+}

--- a/src/services/evm/helpers/contract_helper.ts
+++ b/src/services/evm/helpers/contract_helper.ts
@@ -1,0 +1,114 @@
+import _ from 'lodash';
+import { ethers } from 'ethers';
+import {
+  EIPProxyContractSupportByteCode,
+  DetectEVMProxyContract,
+  EVM_PREFIX,
+  NULL_BYTE_CODE,
+  EVM_DEFAULT_SLOT_BYTE_CODE_LENGTH,
+  ZERO_ADDRESS,
+} from '../constant';
+
+export class ContractHelper {
+  private etherJsClient: ethers.AbstractProvider;
+
+  constructor(etherJsClient: ethers.AbstractProvider) {
+    this.etherJsClient = etherJsClient;
+  }
+
+  public async detectProxyContractByByteCode(
+    contractAddress: string,
+    byteCode: string,
+    byteCodeSlot: string,
+    blockHeight?: number | string
+  ): Promise<DetectEVMProxyContract> {
+    const resultReturn: DetectEVMProxyContract = {
+      logicContractAddress: '',
+      EIP: '',
+    };
+    const result = byteCode.includes(byteCodeSlot);
+
+    if (!result) throw Error('Not proxy contract!');
+
+    const storageSlotValue = await this.etherJsClient.getStorage(
+      contractAddress,
+      `${EVM_PREFIX}${byteCodeSlot}`,
+      blockHeight || 'latest'
+    );
+
+    if (storageSlotValue === '0x' || storageSlotValue === NULL_BYTE_CODE)
+      throw Error('Invalid contract address!');
+
+    const logicAddress =
+      storageSlotValue.length === EVM_DEFAULT_SLOT_BYTE_CODE_LENGTH
+        ? `${EVM_PREFIX}${storageSlotValue.slice(-40)}`
+        : storageSlotValue;
+
+    if (logicAddress === ZERO_ADDRESS) throw Error('Zero contract detected!');
+
+    resultReturn.logicContractAddress = logicAddress;
+    resultReturn.EIP = _.find(
+      EIPProxyContractSupportByteCode,
+      (val) => val.SLOT === byteCodeSlot
+    )?.TYPE;
+    return resultReturn;
+  }
+
+  // Detect contract is proxy contract or not
+  public async isContractProxy(
+    contractAddress: string,
+    blockHeight?: number | string,
+    byteCodeSlot?: string
+  ): Promise<DetectEVMProxyContract | null> {
+    const byteCode = await this.etherJsClient.getCode(contractAddress);
+    let result: DetectEVMProxyContract | null;
+
+    try {
+      if (byteCodeSlot) {
+        result = await this.detectProxyContractByByteCode(
+          contractAddress,
+          byteCode,
+          byteCodeSlot,
+          blockHeight
+        );
+      } else {
+        result = await Promise.any([
+          this.detectProxyContractByByteCode(
+            contractAddress,
+            byteCode,
+            EIPProxyContractSupportByteCode.EIP_1967_ADMIN.SLOT,
+            blockHeight
+          ),
+          this.detectProxyContractByByteCode(
+            contractAddress,
+            byteCode,
+            EIPProxyContractSupportByteCode.EIP_1967_IMPLEMENTATION.SLOT,
+            blockHeight
+          ),
+          this.detectProxyContractByByteCode(
+            contractAddress,
+            byteCode,
+            EIPProxyContractSupportByteCode.EIP_1967_BEACON.SLOT,
+            blockHeight
+          ),
+          this.detectProxyContractByByteCode(
+            contractAddress,
+            byteCode,
+            EIPProxyContractSupportByteCode.EIP_1822_IMPLEMENTATION.SLOT,
+            blockHeight
+          ),
+          this.detectProxyContractByByteCode(
+            contractAddress,
+            byteCode,
+            EIPProxyContractSupportByteCode.OPEN_ZEPPELIN_IMPLEMENTATION.SLOT,
+            blockHeight
+          ),
+        ]);
+      }
+    } catch (error) {
+      result = null;
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new database table to track historical data for Ethereum Virtual Machine (EVM) proxy contracts.
	- Added functionality for handling and tracking proxy contracts, including support for different proxy types and ERC1967 events.
	- Launched a new service for crawling Ethereum blockchain events related to proxy contracts, capable of tracking changes in admin and implementation addresses.

- **Refactor**
	- Updated contract type detection logic and simplified proxy detection methods.
	- Consolidated contract proxy detection into a new `ContractHelper` class for improved efficiency.

- **Chores**
	- Added and updated constants and configurations related to proxy contracts handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->