### PR TITLE
fix: null token id (case approval all)

### DIFF
--- a/src/services/evm/erc721.service.ts
+++ b/src/services/evm/erc721.service.ts
@@ -138,7 +138,8 @@ export default class Erc721Service extends BullableService {
               ['erc721_contract_address', 'token_id'],
               erc721Activities.map((e) => [
                 e.erc721_contract_address,
-                e.token_id,
+                // if token_id undefined (case approval_all), replace by null => not get any token (because token must have token_id)
+                e.token_id || null,
               ])
             )
             .transacting(trx),


### PR DESCRIPTION
Em có thể chỉnh sửa chỉ lấy ra các token liên quan đến transfer, nhưng có thể sau này cần xử lý approval và approval all nên em sẽ giữ nguyên logic lấy tất cả các token liên quan đến transfer/approval/approvalAll
Bug: Do token_id là undefined ko bind được vào query => thay thế bởi null