### PR TITLE
fix: use lib @shazow/whatsabi to get selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@horoscope/sei-js-proto": "3.1.9",
         "@osmonauts/lcd": "^0.10.0",
         "@ourparentcenter/moleculer-decorators-extended": "^1.1.1",
+        "@shazow/whatsabi": "^0.11.0",
         "@tendermint/amino-js": "^0.6.2",
         "@types/parse-uri": "^1.0.0",
         "ajv-formats": "^2.1.1",
@@ -6630,6 +6631,17 @@
         "@seald-io/binary-search-tree": "^1.0.2",
         "localforage": "^1.9.0",
         "util": "^0.12.4"
+      }
+    },
+    "node_modules/@shazow/whatsabi": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@shazow/whatsabi/-/whatsabi-0.11.0.tgz",
+      "integrity": "sha512-dIjhgynJeqPLwSI179E37yFElq+IDyy6xBk9fthkhZp/NO6o2AvtJUq9hWotCBNX/ZQzh6ak7CmdHevwralW8w==",
+      "dependencies": {
+        "ethers": "^6.10.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@horoscope/sei-js-proto": "3.1.9",
     "@osmonauts/lcd": "^0.10.0",
     "@ourparentcenter/moleculer-decorators-extended": "^1.1.1",
-    "@horoscope/sei-js-proto": "3.1.9",
+    "@shazow/whatsabi": "^0.11.0",
     "@tendermint/amino-js": "^0.6.2",
     "@types/parse-uri": "^1.0.0",
     "ajv-formats": "^2.1.1",

--- a/src/services/evm/crawl_contract_evm.service.ts
+++ b/src/services/evm/crawl_contract_evm.service.ts
@@ -2,6 +2,7 @@ import { Service } from '@ourparentcenter/moleculer-decorators-extended';
 import { ServiceBroker } from 'moleculer';
 import _ from 'lodash';
 import { ethers, keccak256 } from 'ethers';
+import { whatsabi } from '@shazow/whatsabi';
 import EtherJsClient from '../../common/utils/etherjs_client';
 import {
   BlockCheckpoint,
@@ -204,23 +205,26 @@ export default class CrawlSmartContractEVMService extends BullableService {
   }
 
   detectContractTypeByCode(code: string): string | null {
+    const selectors = whatsabi
+      .selectorsFromBytecode(code)
+      .map((selector) => selector.slice(2, 10));
     if (
       EVM_CONTRACT_METHOD_HEX_PREFIX.ABI_INTERFACE_ERC20.every((method) =>
-        code.includes(method)
+        selectors.includes(method)
       )
     ) {
       return EVMSmartContract.TYPES.ERC20;
     }
     if (
       EVM_CONTRACT_METHOD_HEX_PREFIX.ABI_INTERFACE_ERC721.every((method) =>
-        code.includes(method)
+        selectors.includes(method)
       )
     ) {
       return EVMSmartContract.TYPES.ERC721;
     }
     if (
       EVM_CONTRACT_METHOD_HEX_PREFIX.ABI_INTERFACE_ERC1155.every((method) =>
-        code.includes(method)
+        selectors.includes(method)
       )
     ) {
       return EVMSmartContract.TYPES.ERC1155;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Replaced the internal library for EVM smart contract detection with `@shazow/whatsabi` for better performance and accuracy.

This update improves the efficiency and reliability of EVM smart contract type detection without impacting the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->