### PR TITLE
fix: erc20 update total supply

### DIFF
--- a/src/common/utils/db_connection.ts
+++ b/src/common/utils/db_connection.ts
@@ -1,4 +1,4 @@
-import Knex from 'knex';
+import Knex, { Knex as IKnex } from 'knex';
 import knexConfig from '../../../knexfile';
 
 const environment = process.env.NODE_ENV || 'development';
@@ -6,3 +6,34 @@ const cfg = knexConfig[environment];
 const knex = Knex(cfg);
 
 export default knex;
+
+export async function batchUpdate(
+  trx: IKnex.Transaction,
+  tableName: string,
+  records: any,
+  fields: string[]
+) {
+  if (records.length === 0) return;
+  const stringListUpdates = records
+    .map((record: any) => {
+      const values = fields.map((field) => {
+        if (record[field]?.type === 'timestamp') {
+          return `to_timestamp(${record[field].value})`;
+        }
+
+        if (record[field] !== undefined) {
+          return `'${record[field]}'`;
+        }
+        return 'NULL';
+      });
+      return `(${record.id}, ${values.join(', ')})`;
+    })
+    .join(',');
+  const query = `
+      UPDATE ${tableName}
+      SET ${fields.map((field) => `${field} = temp.${field}`).join(', ')}
+      FROM (VALUES ${stringListUpdates}) AS temp(id, ${fields.join(', ')})
+      WHERE temp.id = ${tableName}.id
+    `;
+  await trx.raw(query);
+}

--- a/src/common/utils/db_connection.ts
+++ b/src/common/utils/db_connection.ts
@@ -1,4 +1,4 @@
-import Knex, { Knex as IKnex } from 'knex';
+import Knex from 'knex';
 import knexConfig from '../../../knexfile';
 
 const environment = process.env.NODE_ENV || 'development';
@@ -6,34 +6,3 @@ const cfg = knexConfig[environment];
 const knex = Knex(cfg);
 
 export default knex;
-
-export async function batchUpdate(
-  trx: IKnex.Transaction,
-  tableName: string,
-  records: any,
-  fields: string[]
-) {
-  if (records.length === 0) return;
-  const stringListUpdates = records
-    .map((record: any) => {
-      const values = fields.map((field) => {
-        if (record[field]?.type === 'timestamp') {
-          return `to_timestamp(${record[field].value})`;
-        }
-
-        if (record[field] !== undefined) {
-          return `'${record[field]}'`;
-        }
-        return 'NULL';
-      });
-      return `(${record.id}, ${values.join(', ')})`;
-    })
-    .join(',');
-  const query = `
-      UPDATE ${tableName}
-      SET ${fields.map((field) => `${field} = temp.${field}`).join(', ')}
-      FROM (VALUES ${stringListUpdates}) AS temp(id, ${fields.join(', ')})
-      WHERE temp.id = ${tableName}.id
-    `;
-  await trx.raw(query);
-}

--- a/src/services/evm/erc20.service.ts
+++ b/src/services/evm/erc20.service.ts
@@ -1,4 +1,3 @@
-import { QueryModuleAccountByNameResponseSDKType } from '@aura-nw/aurajs/types/codegen/cosmos/auth/v1beta1/query';
 import {
   Action,
   Service,
@@ -9,7 +8,7 @@ import { Context, ServiceBroker } from 'moleculer';
 import { PublicClient, getContract } from 'viem';
 import config from '../../../config.json' assert { type: 'json' };
 import BullableService, { QueueHandler } from '../../base/bullable.service';
-import { SERVICE as COSMOS_SERVICE, Config, getLcdClient } from '../../common';
+import { SERVICE as COSMOS_SERVICE, Config } from '../../common';
 import knex from '../../common/utils/db_connection';
 import { getViemClient } from '../../common/utils/etherjs_client';
 import { BlockCheckpoint, EVMSmartContract } from '../../models';
@@ -27,8 +26,6 @@ const { NODE_ENV } = Config;
 })
 export default class Erc20Service extends BullableService {
   viemClient!: PublicClient;
-
-  erc20ModuleAccount!: string;
 
   public constructor(public broker: ServiceBroker) {
     super(broker);
@@ -352,17 +349,6 @@ export default class Erc20Service extends BullableService {
   public async _start(): Promise<void> {
     this.viemClient = getViemClient();
     if (NODE_ENV !== 'test') {
-      if (config.evmOnly === false) {
-        const lcdClient = await getLcdClient();
-        const erc20Account: QueryModuleAccountByNameResponseSDKType =
-          await lcdClient.provider.cosmos.auth.v1beta1.moduleAccountByName({
-            name: 'erc20',
-          });
-        Erc20Handler.erc20ModuleAccount =
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          erc20Account.account.base_account.address;
-      }
       await this.createJob(
         BULL_JOB_NAME.HANDLE_ERC20_CONTRACT,
         BULL_JOB_NAME.HANDLE_ERC20_CONTRACT,

--- a/test/unit/services/evm/erc20_handler.spec.ts
+++ b/test/unit/services/evm/erc20_handler.spec.ts
@@ -770,18 +770,9 @@ export default class Erc20HandlerTest {
       }),
     };
     const erc20Handler = new Erc20Handler(accountBalances, [], erc20Contracts);
-    erc20Handler.handlerErc20Transfer(erc20Activity);
-    expect(erc20Handler.accountBalances[fromKey]).toMatchObject({
-      denom: erc20Activity.erc20_contract_address,
-      amount: fromAmount,
-    });
-    expect(erc20Handler.accountBalances[toKey]).toMatchObject({
-      denom: erc20Activity.erc20_contract_address,
-      amount: (BigInt(erc20Activity.amount) + BigInt(toAmount)).toString(),
-    });
-    expect(
-      erc20Contracts[erc20Activity.erc20_contract_address].total_supply
-    ).toEqual(totalSupply);
+    expect(() => erc20Handler.handlerErc20Transfer(erc20Activity)).toThrow(
+      `Process erc20 balance: fromAccountBalance ${erc20Activity.from} was updated`
+    );
   }
 
   @Test('test handlerErc20Transfer when from/to is erc20 module account')

--- a/test/unit/services/evm/erc20_handler.spec.ts
+++ b/test/unit/services/evm/erc20_handler.spec.ts
@@ -29,7 +29,6 @@ import {
   ERC20_ACTION,
   Erc20Handler,
 } from '../../../../src/services/evm/erc20_handler';
-import { convertBech32AddressToEthAddress } from '../../../../src/services/evm/utils';
 
 const evmTransaction = EVMTransaction.fromJson({
   id: 2931,
@@ -97,7 +96,6 @@ export default class Erc20HandlerTest {
       wrapSmartContract,
     ]);
     await Erc20Contract.query().insert([erc20Contract, erc20WrapContract]);
-    Erc20Handler.erc20ModuleAccount = erc20ModuleAccount;
   }
 
   @AfterAll()
@@ -422,10 +420,7 @@ export default class Erc20HandlerTest {
       // test convert coin activity
       const convertCoinActivity = erc20Activitites[0];
       expect(convertCoinActivity).toMatchObject({
-        from: convertBech32AddressToEthAddress(
-          config.networkPrefixAddress,
-          erc20ModuleAccount
-        ).toLowerCase(),
+        from: ZERO_ADDRESS,
         to,
         amount,
         action: ERC20_ACTION.TRANSFER,
@@ -436,10 +431,7 @@ export default class Erc20HandlerTest {
       const convertErc20Activity = erc20Activitites[1];
       expect(convertErc20Activity).toMatchObject({
         from,
-        to: convertBech32AddressToEthAddress(
-          config.networkPrefixAddress,
-          erc20ModuleAccount
-        ).toLowerCase(),
+        to: ZERO_ADDRESS,
         amount,
         action: ERC20_ACTION.TRANSFER,
         erc20_contract_address: erc20Contract.address,
@@ -801,10 +793,7 @@ export default class Erc20HandlerTest {
       erc20_contract_address: '0x98605ae21dd3be686337a6d7a8f156d0d8baee92',
       amount: '12345222',
       from: '0xD83E708D7FE0E769Af80d990f9241458734808Ac',
-      to: convertBech32AddressToEthAddress(
-        config.networkPrefixAddress,
-        erc20ModuleAccount
-      ).toLowerCase(),
+      to: ZERO_ADDRESS,
       height: 10000,
       tx_hash:
         '0xb97228e533e3af1323d873c9c3e4c0a9b85d95ecd8e98110c8890c9453d2f077',

--- a/test/unit/services/evm/erc20_reindex.spec.ts
+++ b/test/unit/services/evm/erc20_reindex.spec.ts
@@ -148,7 +148,8 @@ export default class Erc20ReindexTest {
   @Test('test reindex')
   async testReindex() {
     const viemClient = getViemClient();
-    Erc20Handler.erc20ModuleAccount = '0x0000000000000dfd';
+    Erc20Handler.erc20ModuleAccount =
+      'aura16st9fmex8xjdahwzwxldhjm2ssu6utw8rnxlkj';
     jest.spyOn(viemClient, 'getBlockNumber').mockResolvedValue(BigInt(123456));
     // Instantiate Erc20Reindexer with the mock
     const reindexer = new Erc20Reindexer(viemClient, this.broker.logger);

--- a/test/unit/services/evm/erc20_reindex.spec.ts
+++ b/test/unit/services/evm/erc20_reindex.spec.ts
@@ -13,10 +13,7 @@ import {
   EVMSmartContract,
   EVMTransaction,
 } from '../../../../src/models';
-import {
-  ABI_TRANSFER_PARAMS,
-  Erc20Handler,
-} from '../../../../src/services/evm/erc20_handler';
+import { ABI_TRANSFER_PARAMS } from '../../../../src/services/evm/erc20_handler';
 import { Erc20Reindexer } from '../../../../src/services/evm/erc20_reindex';
 
 const accounts = [
@@ -148,8 +145,6 @@ export default class Erc20ReindexTest {
   @Test('test reindex')
   async testReindex() {
     const viemClient = getViemClient();
-    Erc20Handler.erc20ModuleAccount =
-      'aura16st9fmex8xjdahwzwxldhjm2ssu6utw8rnxlkj';
     jest.spyOn(viemClient, 'getBlockNumber').mockResolvedValue(BigInt(123456));
     // Instantiate Erc20Reindexer with the mock
     const reindexer = new Erc20Reindexer(viemClient, this.broker.logger);


### PR DESCRIPTION
- Fix erc20 convert coin/erc20 logic: mint/burn erc20 not from erc20 module account. It is caused by normal mint/burn (openzepplin), so update address => ZERO_ADDRESS
- Update total_supply: if transfer from (to) zero => add (sub) total_supply