### PR TITLE
feat: erc20 reindex too big contract

### DIFF
--- a/ci/config.json.ci
+++ b/ci/config.json.ci
@@ -404,7 +404,10 @@
     "blocksPerCall": 100,
     "millisecondRepeatJob": 5000,
     "chunkSizeInsert": 1000,
-    "wrapExtensionContract": ["0xe974cc14c93fc6077b0d65f98832b846c5454a0b"]
+    "wrapExtensionContract": ["0xe974cc14c93fc6077b0d65f98832b846c5454a0b"],
+    "reindex": {
+      "limitRecordGet": 2000
+    }
   },
   "erc721": {
     "key": "erc721",

--- a/config.json
+++ b/config.json
@@ -402,7 +402,10 @@
     "blocksPerCall": 100,
     "millisecondRepeatJob": 2000,
     "chunkSizeInsert": 1000,
-    "wrapExtensionContract": ["0xe974cc14c93fc6077b0d65f98832b846c5454a0b"]
+    "wrapExtensionContract": ["0xe974cc14c93fc6077b0d65f98832b846c5454a0b"],
+    "reindex": {
+      "limitRecordGet": 2000
+    }
   },
   "erc721": {
     "key": "erc721",

--- a/src/services/evm/erc20.service.ts
+++ b/src/services/evm/erc20.service.ts
@@ -90,13 +90,12 @@ export default class Erc20Service extends BullableService {
           ],
           config.erc20.key
         );
-      const erc20Activities: Erc20Activity[] =
-        await Erc20Handler.buildErc20Activities(
-          startBlock,
-          endBlock,
-          trx,
-          this.logger
-        );
+      const { erc20Activities } = await Erc20Handler.buildErc20Activities(
+        startBlock,
+        endBlock,
+        trx,
+        this.logger
+      );
       await this.handleMissingErc20Contract(erc20Activities, trx);
       if (erc20Activities.length > 0) {
         this.logger.info(

--- a/src/services/evm/erc20_handler.ts
+++ b/src/services/evm/erc20_handler.ts
@@ -170,7 +170,12 @@ export class Erc20Handler {
     endBlock: number,
     trx: Knex.Transaction,
     logger: Moleculer.LoggerInstance,
-    addresses?: string[]
+    addresses?: string[],
+    page?: {
+      prevEvmEventId?: number;
+      limitRecordGet: number;
+      prevCosmosEventId?: number;
+    }
   ) {
     const erc20Activities: Erc20Activity[] = [];
     const erc20Events = await EvmEvent.query()
@@ -184,6 +189,11 @@ export class Erc20Handler {
       .modify((builder) => {
         if (addresses) {
           builder.whereIn('evm_event.address', addresses);
+        }
+        if (page && page.prevEvmEventId !== undefined) {
+          builder
+            .andWhere('evm_event.id', '>', page.prevEvmEventId)
+            .limit(page.limitRecordGet);
         }
       })
       .where('evm_event.block_height', '>', startBlock)
@@ -212,6 +222,11 @@ export class Erc20Handler {
               .joinRelated('attributes')
               .where('attributes.key', EventAttribute.ATTRIBUTE_KEY.ERC20_TOKEN)
               .whereIn(knex.raw('lower("value")'), addresses);
+          }
+          if (page && page.prevCosmosEventId !== undefined) {
+            builder
+              .andWhere('event.id', '>', page.prevCosmosEventId)
+              .limit(page.limitRecordGet);
           }
         })
         .withGraphFetched('[transaction, attributes]')
@@ -244,14 +259,19 @@ export class Erc20Handler {
         erc20Activities.push(activity);
       }
     });
-    return _.sortBy(erc20Activities, 'cosmos_tx_id');
+    return {
+      erc20Activities: _.sortBy(erc20Activities, 'cosmos_tx_id'),
+      prevEvmEventId: erc20Events[erc20Events.length - 1]?.id,
+      prevCosmosEventId: erc20CosmosEvents[erc20CosmosEvents.length - 1]?.id,
+    };
   }
 
   static async getErc20Activities(
     startBlock: number,
     endBlock: number,
     trx?: Knex.Transaction,
-    addresses?: string[]
+    addresses?: string[],
+    page?: { prevId: number; limitRecordGet: number }
   ): Promise<Erc20Activity[]> {
     return Erc20Activity.query()
       .modify((builder) => {
@@ -260,6 +280,11 @@ export class Erc20Handler {
         }
         if (trx) {
           builder.transacting(trx);
+        }
+        if (page) {
+          builder
+            .andWhere('erc20_activity.id', '>', page.prevId)
+            .limit(page.limitRecordGet);
         }
       })
       .leftJoin(


### PR DESCRIPTION
For erc20 contracts which have too much activities for handling (build, insert, calc balance), i need to separate those activities to chunks and handle them sequentially.
This pull has been tested in evm branch #879 