### PR TITLE
docs: Add README for CW20 services

### DIFF
--- a/src/services/cw20/cw20.md
+++ b/src/services/cw20/cw20.md
@@ -1,0 +1,44 @@
+# Horoscope-v2 CW20 Services
+
+This folder contains Moleculer services responsible for handling CW20 token data within the Horoscope-v2 application.  These services interact with a database to track token holders, balances, and transaction history.
+
+## File Descriptions
+
+* **`cw20_update_by_contract.service.ts`**: This service updates CW20 token holder balances and total supply based on new events within a specified block range for a given contract. It uses a queue system for processing.
+
+* **`cw20_reindexing.service.ts`**: This service handles the complete re-indexing of a CW20 contract. It deletes existing data for the contract and rebuilds it from scratch, using other services to process the historical data.
+
+* **`cw20.service.ts`**: This service is the main entry point for processing CW20 events. It handles the scheduling of jobs to process blocks and instantiates new CW20 contracts. It also manages the re-indexing of historical CW20 data.
+
+
+## Usage Instructions
+
+These services are designed to be used within a Moleculer application.  They are not standalone executables.  To utilize them:
+
+1. **Ensure you have a Moleculer application set up.**
+2. **Install dependencies:**  See the "Dependencies" section below.
+3. **Register the services:**  Import and register these services within your Moleculer application's service registry.
+4. **Trigger processing:** The `cw20.service.ts` service starts a recurring job (`BULL_JOB_NAME.HANDLE_CW20`) to process new blocks.  `cw20_reindexing.service.ts` can be called directly via its action (`SERVICE.V1.Cw20ReindexingService.Reindexing`) to reindex a specific contract.
+
+
+## Dependencies
+
+* `@ourparentcenter/moleculer-decorators-extended`
+* `moleculer`
+* `knex`
+* `lodash`
+* `bullmq`
+
+
+## Additional Notes
+
+* The services use a queue system (BullMQ) to handle asynchronous processing of blocks and prevent overwhelming the database.
+* Configuration is loaded from `config.json`.  Ensure this file is correctly configured.
+* The services interact with database models defined elsewhere in the project (e.g., `Cw20Contract`, `Cw20Activity`, `CW20Holder`).
+* Error handling is implemented within the services, but appropriate logging and monitoring should be added in a production environment.
+* The `cw20_reindexing` service performs a full delete and re-insert operation, which could be slow for large contracts.
+
+
+## Input Files
+
+The input files are the blockchain events processed by these services.  These are not directly used as input files in the conventional sense, but are consumed by the services to update the database.  The specific format of these events is not detailed here but is defined within the application's data model.


### PR DESCRIPTION
This PR adds a README file to the `horoscope-v2/agent/.repos/aura-nw/horoscope-v2` CW20 services folder, documenting the services, their usage, dependencies, and other relevant information.