### PR TITLE
docs: Add README for CW20 services

### DIFF
--- a/src/services/cw20/cw20.md
+++ b/src/services/cw20/cw20.md
@@ -1,0 +1,52 @@
+# Horoscope-v2 CW20 Services
+
+This folder contains Moleculer services responsible for handling CW20 token data within the Horoscope-v2 application.  These services interact with a database to track token balances, transactions, and contract information.
+
+## File Descriptions
+
+* **`cw20_update_by_contract.service.ts`**: This service updates CW20 token holder balances and total supply based on new events within a specified block range for a given contract. It uses a job queue to process updates in batches.
+
+* **`cw20_reindexing.service.ts`**: This service handles the re-indexing of a CW20 contract. It deletes existing data for a contract, re-imports initial balances, and then uses `cw20_update_by_contract.service.ts` to update the data to the latest block.
+
+* **`cw20.service.ts`**: This is the main service responsible for processing CW20 events. It fetches events from a blockchain, handles contract instantiation, updates historical records, and triggers balance updates using `cw20_update_by_contract.service.ts`. It also manages the periodic execution of CW20 data processing.  It includes functionality for re-indexing historical data.
+
+
+## Usage Instructions
+
+These services are designed to be part of a larger Moleculer application and are not intended to be run independently.  They are invoked internally within the application workflow.  The primary entry points are:
+
+* **`cw20_reindexing.service.ts`**: The `reindexing` action can be called with a contract address to trigger a full reindex of that contract.  This would typically be called from another part of the application.
+
+* **`cw20.service.ts`**: The main service starts a recurring job (`HANDLE_CW20`) which handles the continuous processing of new CW20 events. This job is configured within the application's configuration.
+
+
+## Dependencies
+
+* `@ourparentcenter/moleculer-decorators-extended`: Moleculer service decorators.
+* `moleculer`: The Moleculer framework.
+* `knex`: A SQL query builder.
+* `lodash`: Utility library.
+* `bullmq`: A Redis-based queue.
+
+
+## Dependencies (Implicit)
+
+The code also relies on:
+
+* A database (likely PostgreSQL, based on the use of Knex).
+* A configured Moleculer service broker.
+* A Redis instance (for BullMQ).
+* Configuration files (`config.json`) containing settings like database connection details, job retry parameters, and block processing ranges.  
+*  Models (`CW20Holder`, `Cw20Contract`, `Cw20Activity`, etc.) defined elsewhere in the project.
+
+## Additional Notes
+
+* The services utilize transactions to ensure data consistency.
+* Error handling is implemented, but specific error messages and responses might require further examination of the code.
+* The services are designed to handle large datasets efficiently by processing events in batches.
+* The `config.json` file plays a crucial role in controlling the behavior and parameters of the services, including retry attempts, backoff strategies, and block processing intervals.
+* The re-indexing process involves deleting and recreating data, which should be used cautiously.
+
+## Input Files
+
+The README describes the provided input files (`cw20_update_by_contract.service.ts`, `cw20_reindexing.service.ts`, `cw20.service.ts`).


### PR DESCRIPTION
This PR adds a README file to the `horoscope-v2/agent/.repos/aura-nw/horoscope-v2` directory, documenting the CW20 services: `cw20_update_by_contract.service.ts`, `cw20_reindexing.service.ts`, and `cw20.service.ts`.  The README includes descriptions of each service, usage instructions, dependencies, and important considerations.