### PR TITLE
docs: Add README for CW20 services

### DIFF
--- a/src/services/cw20/cw20.md
+++ b/src/services/cw20/cw20.md
@@ -1,0 +1,48 @@
+# Horoscope-v2 CW20 Services
+
+This folder contains Moleculer services responsible for handling CW20 token data within the Horoscope-v2 application.  These services interact with a database to track token balances, activity, and other relevant information.
+
+## File Descriptions
+
+* **`cw20_update_by_contract.service.ts`**: This service updates CW20 token holder balances and total supply based on new events within a specified block range. It uses a queue system for processing large batches of events.
+
+* **`cw20_reindexing.service.ts`**: This service handles the reindexing of CW20 contracts.  It deletes existing data for a contract, re-processes initial balances, and then updates the data using `cw20_update_by_contract.service.ts`.
+
+* **`cw20.service.ts`**: This is the main service for processing CW20 events. It fetches new events, handles the instantiation of new CW20 contracts, processes historical events, and updates statistics.  It uses a recurring job to continuously process new blocks.
+
+
+## Usage Instructions
+
+These services are designed to run within a Moleculer application.  They cannot be executed directly.  The `cw20.service.ts` service starts a recurring job to handle new CW20 events. The `cw20_reindexing.service.ts` service provides an action (`reindexing`) that can be called to trigger a reindexing of a specific CW20 contract.
+
+To use these services:
+
+1. Ensure you have a running Moleculer application configured correctly.
+2. Register these services within your Moleculer application.
+3. The `cw20.service.ts` will automatically start processing events.
+4. Call the `reindexing` action on `cw20_reindexing.service.ts` to manually reindex a contract, providing the contract address as a parameter.
+
+
+## Dependencies
+
+* `@ourparentcenter/moleculer-decorators-extended`: For Moleculer service decorators.
+* `moleculer`: The Moleculer framework.
+* `knex`: For database interactions.
+* `lodash`: For utility functions.
+* `bullmq`: For queue management.
+
+
+## Dependencies (Specific versions need to be added from package.json)
+
+
+## Additional Notes
+
+* The services utilize a queue system (`bullmq`) to handle events asynchronously and efficiently.
+* Error handling is implemented within the services to manage potential issues during processing.
+* Configuration parameters (e.g., retry attempts, backoff strategies) are loaded from `config.json`.
+* The services interact with database models defined elsewhere in the project (e.g., `Cw20Contract`, `Cw20Activity`, `SmartContract`).
+* The `cw20_reindexing.service.ts` performs a full reindex of the specified contract, which might take a considerable amount of time depending on the contract's history.
+
+## Input Files
+
+The code provided consists of three TypeScript files that define Moleculer services for handling CW20 token data.  These services are interconnected and rely on a shared database and configuration.  The exact input data (blockchain events, etc.) is not included in the provided code snippets but is implicitly handled by these services.


### PR DESCRIPTION
This PR adds a README file to the `horoscope-v2/agent/.repos/aura-nw/horoscope-v2` directory, documenting the CW20 services (`cw20_update_by_contract.service.ts`, `cw20_reindexing.service.ts`, and `cw20.service.ts`).  The README includes descriptions of each service, usage instructions, dependencies, and additional notes.