### PR TITLE
docs: Add README for CW721 services

### DIFF
--- a/src/services/cw721/cw721.md
+++ b/src/services/cw721/cw721.md
@@ -1,0 +1,52 @@
+# Horoscope-v2 CW721 Services
+
+This folder contains TypeScript code for several services related to handling CW721 (CosmWasm 721) tokens within the Horoscope-v2 project.  These services interact with blockchain data, manage token metadata, and update databases.
+
+## File Descriptions
+
+* **`cw721_handler.ts`**: This file defines the `Cw721Handler` class. This class processes CW721 events (mint, burn, transfer) from smart contract logs. It updates token ownership and creates activity records in the database.  It relies on various model classes for data representation.
+
+* **`cw721.service.ts`**: This file implements the `Cw721HandlerService`, a Moleculer service responsible for periodically processing CW721 transactions. It retrieves transactions from the database, uses `Cw721Handler` to process them, and updates the database accordingly. It uses BullMQ for job queueing.
+
+* **`cw721-reindexing.service.ts`**: This file contains the `CW721ReindexingService`, another Moleculer service.  This service handles reindexing of CW721 data, offering both full reindexing and reindexing of historical data. It interacts with other services and manages the reindexing process through job queues.
+
+* **`cw721-media.service.ts`**: This file defines the `Cw721MediaService`, a Moleculer service that handles fetching and storing metadata for CW721 tokens. It downloads metadata from IPFS or other URLs, uploads images and animations to S3, and updates the database with the media information.
+
+
+## Usage Instructions
+
+These services are designed to be part of a larger Moleculer application.  They cannot be executed independently.  To utilize these services:
+
+1. **Ensure Dependencies are Met:**  (See Dependencies section below)
+2. **Integrate into Moleculer Application:**  These services are defined as Moleculer services and need to be registered and configured within your Moleculer application.
+3. **Start the Application:** Start your Moleculer application. The services will then run according to their configured schedules (using BullMQ).  The `cw721-reindexing.service` requires manual triggering via its exposed action.
+
+## Dependencies
+
+* `lodash`
+* `@cosmjs/tendermint-rpc`
+* `@ourparentcenter/moleculer-decorators-extended`
+* `moleculer`
+* `bullmq`
+* `knex`
+* `@cosmjs/encoding`
+* `is-ipfs`
+* `file-type`
+* `parse-uri`
+* `axios`
+* `aws-sdk`
+* `@aura-nw/aurajs` (appears to be a custom library)
+
+
+## Additional Notes
+
+* The code utilizes a database (likely PostgreSQL, judging by the use of `knex`).  Database connection details are configured separately (likely in `config.json`).
+* Error handling is implemented to some degree, but more robust error handling might be necessary for production environments.
+* The services use BullMQ for job queue management, allowing for asynchronous processing and better scalability.
+* The `config.json` file is crucial for configuring various parameters, including database connections, API endpoints, and job schedules.
+* The `@aura-nw/aurajs` library is a project-specific dependency and needs to be properly installed.
+
+
+## Input Files
+
+The README has been generated based on the provided input files.  The detailed description of each file's function is based on code analysis.


### PR DESCRIPTION
This PR adds a README file to the `cw721` services directory, documenting the purpose, usage, dependencies, and file descriptions of the services within.