### PR TITLE
docs: Add README for CW721 services

### DIFF
--- a/src/services/cw721/cw721.md
+++ b/src/services/cw721/cw721.md
@@ -1,0 +1,53 @@
+# Horoscope-v2 CW721 Services
+
+This folder contains the TypeScript code for several services related to handling CW721 (CosmWasm-based NFT) tokens within the Horoscope-v2 project.  These services interact with blockchain data, handle metadata, and manage storage of NFT media.
+
+## File Descriptions
+
+* **`cw721-media.service.ts`**: This service is responsible for fetching, processing, and storing NFT media (images, animations) associated with CW721 tokens. It retrieves metadata from IPFS or other sources, uploads media to S3, and updates database records with the media information.
+
+* **`cw721-reindexing.service.ts`**: This service handles reindexing of CW721 contract data.  It provides functionality to reindex all data for a contract or just the transaction history. It interacts with other services to perform the reindexing process.
+
+* **`cw721.service.ts`**: This is the main service for processing CW721 transactions. It fetches transaction data from the blockchain, processes different types of CW721 actions (mint, burn, transfer), updates the database with token and transaction information, and manages the refresh of CW721 statistics.
+
+* **`cw721_handler.ts`**: This file contains a handler class (`Cw721Handler`) that processes individual CW721 actions (mint, burn, transfer).  It updates token information and creates transaction records in the database.
+
+
+## Usage Instructions
+
+These services are designed to be used within a Moleculer microservices framework.  They are not standalone executable files. To utilize them:
+
+1. **Ensure Dependencies are installed:**  (See Dependencies section below)
+2. **Integrate into Moleculer application:**  Include these services in your Moleculer application configuration.
+3. **Call service actions:**  Use Moleculer's action calling mechanism to trigger the desired functionality. For example, to reindex a CW721 contract, you would call the `reindexing` action of the `cw721-reindexing.service`. Specific action names and parameters are defined within each service file.
+
+## Dependencies
+
+* `@aura-nw/aurajs`
+* `@cosmjs/encoding`
+* `@cosmjs/json-rpc`
+* `@cosmjs/tendermint-rpc`
+* `@ourparentcenter/moleculer-decorators-extended`
+* `axios`
+* `bullmq`
+* `file-type`
+* `is-ipfs`
+* `knex`
+* `lodash`
+* `moleculer`
+* `parse-uri`
+* `aws-sdk`
+
+
+## Additional Notes
+
+* The services utilize a queueing system (BullMQ) to handle asynchronous tasks.
+* Configuration parameters are loaded from `config.json`.
+* Error handling is implemented to gracefully manage potential issues during data processing and network requests.
+* The services interact with a database (likely PostgreSQL, based on the use of Knex.js).
+* IPFS gateway and S3 gateway URLs are configured in `config.json`.
+
+
+## Input Files
+
+This README.md document was generated based on the provided input files.  The descriptions and usage instructions reflect the content of those files.


### PR DESCRIPTION
This PR adds a README file to the `cw721` services directory, documenting the purpose, usage, and dependencies of each service.