### PR TITLE
docs: Add README for CW721 services

### DIFF
--- a/src/services/cw721/cw721.md
+++ b/src/services/cw721/cw721.md
@@ -1,0 +1,55 @@
+# Horoscope-v2 CW721 Services
+
+This folder contains the source code for several services related to managing CW721 tokens within the Horoscope-v2 application.  These services handle metadata updates, reindexing, and transaction processing.
+
+
+## File Descriptions
+
+* **`cw721-media.service.ts`**: This service is responsible for fetching metadata for CW721 tokens from on-chain and off-chain sources (IPFS). It then uploads media (images and animations) to S3 and updates the database with the new media information.
+
+* **`cw721-reindexing.service.ts`**: This service handles the reindexing of CW721 contract data. It provides functionality to reindex all data for a contract or just the transaction history.
+
+* **`cw721.service.ts`**: This is the main service for processing CW721 transactions. It fetches transactions from a block range, handles different transaction types (mint, burn, transfer), updates the database with token and transaction information, and manages the refresh of CW721 statistics.
+
+* **`cw721_handler.ts`**: This file contains a handler class (`Cw721Handler`) that processes individual CW721 transactions, updating token and transaction data accordingly.
+
+
+## Usage Instructions
+
+These services are designed to be used within a Moleculer application and are not meant to be executed directly from the command line.  They are triggered by jobs scheduled through a BullMQ queue.  The `_start` method in each service registers the necessary queue handlers and schedules jobs based on the configuration in `config.json`.
+
+To use these services, you'll need to integrate them into your Moleculer application and configure the BullMQ queues and relevant settings within `config.json`.  The services communicate with each other via Moleculer's service broker.
+
+
+## Dependencies
+
+The services depend on several libraries, including:
+
+* `@aura-nw/aurajs`
+* `@cosmjs/encoding`
+* `@cosmjs/json-rpc`
+* `@cosmjs/tendermint-rpc`
+* `@ourparentcenter/moleculer-decorators-extended`
+* `axios`
+* `bullmq`
+* `file-type`
+* `is-ipfs`
+* `knex`
+* `lodash`
+* `moleculer`
+* `parse-uri`
+* `aws-sdk`
+
+
+## Additional Notes
+
+* The services use a checkpoint system to track progress and avoid redundant processing.
+* Error handling is implemented to gracefully handle failures and prevent data corruption.
+* Configuration parameters are loaded from `config.json`, allowing for flexible customization.
+* IPFS gateway and S3 gateway URLs are configurable.
+* The services rely on a database (likely PostgreSQL, given the use of `knex`) to store and retrieve data.
+
+
+## Input Files
+
+The code for all input files is included above in the problem description.


### PR DESCRIPTION
This PR adds a README file documenting the CW721 services within the Horoscope-v2 application.  The README includes descriptions of each service, usage instructions, dependencies, and additional notes.