### PR TITLE
docs: Add README for CW721 services

### DIFF
--- a/src/services/cw20/cw20.md
+++ b/src/services/cw20/cw20.md
@@ -1,0 +1,50 @@
+# Horoscope-v2 CW20 Services
+
+This folder contains the TypeScript source code for three services related to CW20 token processing within the Horoscope-v2 application.  These services work together to index, update, and reindex CW20 token data.
+
+## File Descriptions
+
+* **`cw20.service.ts`**: This service is the core processor for CW20 token events. It retrieves events from a specified block range, handles contract instantiation, processes transfer and mint/burn events, updates contract statistics (total supply and holder count), and schedules itself to run periodically.  It also includes a function for reindexing historical data.
+
+* **`cw20_reindexing.service.ts`**: This service provides an API endpoint to trigger a full reindexing of a specific CW20 contract. It handles job creation and orchestration for the reindexing process.
+
+* **`cw20_update_by_contract.service.ts`**: This service updates the balances of CW20 token holders and the total supply of a specific contract based on new events within a given block range. It's called by other services after new events are processed.
+
+
+## Usage Instructions
+
+These services are designed to run as part of a Moleculer microservices architecture.  They cannot be executed independently.  To use them, you need to integrate them into a Moleculer application and configure the necessary database connections and queueing system (BullMQ).
+
+**`cw20.service.ts`**: This service is started automatically by the Moleculer framework after its dependencies are available.  It uses BullMQ jobs (`BULL_JOB_NAME.HANDLE_CW20`) for periodic processing of CW20 events.  The reindexing functionality is triggered via the BullMQ job queue  (`BULL_JOB_NAME.REINDEX_CW20_HISTORY`).
+
+**`cw20_reindexing.service.ts`**:  The reindexing process is triggered by calling the `reindexing` action with a contract address:
+
+```bash
+# This command would be part of your Moleculer application's API or internal communication.
+moleculer call cw20_reindexing.v1.reindexing contractAddress=<CONTRACT_ADDRESS>
+```
+
+**`cw20_update_by_contract.service.ts`**: This service is called internally by `cw20.service.ts` and `cw20_reindexing.service.ts`. It does not have a directly accessible API endpoint.
+
+
+## Dependencies
+
+* `@ourparentcenter/moleculer-decorators-extended`: Moleculer service decorators.
+* `bullmq`: A message queue library.
+* `knex`: A SQL query builder.
+* `lodash`: Utility library.
+* `moleculer`: Microservice framework.
+* PostgreSQL (database)
+
+
+## Additional Notes
+
+* The services utilize a database (PostgreSQL) to store CW20 contract information, holder balances, and transaction history.
+* The `config.json` file contains crucial settings like database credentials, queue configurations, and block processing parameters.
+* Error handling is implemented throughout the services, including retry mechanisms for failed jobs.
+* The `_blocksPerBatch` variable (in `cw20.service.ts` and `cw20_update_by_contract.service.ts`) likely controls the number of blocks processed in each batch, optimizing performance.  The optimal value would depend on your specific needs and system resources.
+
+
+## Input Files
+
+The README describes the input files (`cw20.service.ts`, `cw20_reindexing.service.ts`, `cw20_update_by_contract.service.ts`) provided.


### PR DESCRIPTION
This PR adds a README file to the `cw721-services` directory, documenting the purpose, usage, dependencies, and functionality of the various services related to managing CW721 tokens within the Horoscope-v2 application.