### PR TITLE
feat: Add README for CW721 Services

### DIFF
--- a/src/services/cw721/cw721.md
+++ b/src/services/cw721/cw721.md
@@ -1,0 +1,74 @@
+```markdown
+# CW721 Services
+
+This folder contains services for handling CW721 contracts, tokens, and media within the horoscope-v2 project. It includes functionalities for indexing, reindexing, and managing media assets associated with CW721 tokens.
+
+## File Descriptions
+
+-   **`cw721-media.service.ts`**: This service is responsible for handling media (images and animations) associated with CW721 tokens. It fetches metadata, downloads media files, uploads them to S3, and updates the token's media information in the database.
+
+-   **`cw721-reindexing.service.ts`**: This service handles the reindexing of CW721 contracts and their associated data. It supports full reindexing (deleting and recreating all data) and history reindexing (updating activity history).
+
+-   **`cw721.service.ts`**: This is the main service for handling CW721 transactions. It processes events related to CW721 contracts, including minting, burning, and transferring tokens. It also calculates and updates contract statistics.
+
+-   **`cw721_handler.ts`**: This file contains the `Cw721Handler` class, which is responsible for processing CW721 messages and updating the state of tokens and activities based on the events.
+
+## Usage Instructions
+
+### `cw721-media.service.ts`
+
+-   **Execution:** This service runs as a Moleculer service and uses BullMQ for queue management. It does not require direct execution. Jobs are created and processed automatically based on events.
+-   **Functionality:** It processes token media by fetching metadata from `token_uri`, downloading media files, and storing the information in S3.
+
+### `cw721-reindexing.service.ts`
+
+-   **Execution:** This service runs as a Moleculer service. It exposes an action `reindexing` that can be called to trigger the reindexing of specified CW721 contracts.
+-   **Command-line usage:** The service is designed to be called via Moleculer actions, not directly from the command line. Example:
+    ```bash
+    # Using moleculer cli or equivalent client
+    mol actions v1.cw721-reindexing-service.reindexing --contractAddresses '["<contract_address_1>", "<contract_address_2>"]' --type "all"
+    ```
+    or
+     ```bash
+    mol actions v1.cw721-reindexing-service.reindexing --contractAddresses '["<contract_address_1>", "<contract_address_2>"]' --type "history"
+    ```
+
+-   **Functionality:** It allows for full reindexing (`type: 'all'`) or historical reindexing (`type: 'history'`) of CW721 contracts.
+
+### `cw721.service.ts`
+
+-   **Execution:** This service runs as a Moleculer service and uses BullMQ for queue management. It does not require direct execution.
+-   **Functionality:** It automatically handles CW721 transactions by processing contract events, updating token owners, and storing activity history. It also calculates and refreshes contract statistics periodically.
+-   It also provides an action `handleRangeBlockMissingContract` to process events from missing blocks.
+
+### `cw721_handler.ts`
+
+-   **Execution:** This file does not contain an executable service but rather a class used by `cw721.service.ts`.
+-   **Functionality:**  It processes CW721 messages, updating token ownership, burning status and recording activities in the database.
+
+## Dependencies
+
+-   `@aura-nw/aurajs`: Used for interacting with the Aura network.
+-   `@cosmjs/encoding`: Used for encoding and decoding data.
+-   `@cosmjs/json-rpc`: Used for making JSON-RPC requests.
+-   `@ourparentcenter/moleculer-decorators-extended`: Used for Moleculer service decorators.
+-   `moleculer`: Core Moleculer framework.
+-   `is-ipfs`: Used to check if a string is an IPFS URL.
+-   `file-type`: Used to determine the MIME type of a file.
+-    `parse-uri`: Used to parse URI strings
+-   `axios`: Used for making HTTP requests.
+-   `aws-sdk`: Used for interacting with AWS S3.
+-   `lodash`: Utility library for functional programming.
+-   `bullmq`: Queue library for managing background jobs.
+-   `knex`: SQL query builder.
+
+## Additional Notes
+
+-   The services use a configuration file (`config.json`) for various settings like concurrency, timeouts, S3 bucket names, and repeat intervals.
+-   The `cw721-media.service.ts` attempts to download and upload media files, handling both IPFS and HTTP URLs.
+-   The `cw721-reindexing.service.ts` is primarily used for correcting inconsistencies in data or re-crawling existing contracts.
+-   The `cw721.service.ts` uses a checkpoint mechanism to track its progress in processing blocks, ensuring no blocks are missed or processed twice.
+-   The `cw721_handler.ts` is a core class for processing different CW721 actions and updates data accordingly.
+-   Error handling is implemented in all services, including retries for failed jobs.
+-   The services use logging for monitoring and debugging.
+```


### PR DESCRIPTION
This PR introduces a comprehensive README file detailing the purpose, functionality, and usage of the CW721 services. It provides information on each service, including `cw721-media.service.ts`, `cw721-reindexing.service.ts`, `cw721.service.ts`, and `cw721_handler.ts`. The README also outlines dependencies and general notes.